### PR TITLE
feat: make `Any` support Codable, like: [String: Any], [Any]

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
   workflow_dispatch:	
 
 jobs:

--- a/ExCodable.podspec
+++ b/ExCodable.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
     
     # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.license       = "MIT"
-    s.author        = { "Mr. Ming" => "i+ExCodable@iwill.im" }
+    s.author        = { "Mr. Míng" => "i+ExCodable@iwill.im" }
     s.social_media_url = "https://iwill.im/about/"
     
     # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/ExCodable.podspec
+++ b/ExCodable.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
     # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
     s.name          = "ExCodable"
     # export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
-    s.version       = ENV["LIB_VERSION"] || "0.5.0"
+    s.version       = ENV["LIB_VERSION"] || "1.0.0-alpha"
     s.summary       = "Key-Mapping Extensions for Swift Codable"
     # s.description   = "Key-Mapping Extensions for Swift Codable."
     s.homepage      = "https://github.com/iwill/ExCodable"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Mr. Ming
+Copyright (c) 2021 Mr. Míng
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Mr. Míng
+Copyright (c) 2022 Mr. Míng
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ pod 'ExCodable', '~> 0.5.0'
 
 - John Sundell ([@JohnSundell](https://github.com/JohnSundell)) and the ideas from his [Codextended](https://github.com/JohnSundell/Codextended)
 - ibireme ([@ibireme](https://github.com/ibireme)) and the features from his [YYModel](https://github.com/ibireme/YYModel)
-- Mr. Ming ([@iwill](https://github.com/iwill)) | i+ExCodable@iwill.im
+- Mr. Míng ([@iwill](https://github.com/iwill)) | i+ExCodable@iwill.im
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 [![Swift 5.0](https://img.shields.io/badge/Swift-5.0-orange.svg)](https://swift.org/)
 [![Swift Package Manager](https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager/)
 [![Platforms](https://img.shields.io/cocoapods/p/ExCodable.svg)](#readme)
+<br />
 [![Build and Test](https://github.com/iwill/ExCodable/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/iwill/ExCodable/actions/workflows/build-and-test.yml)
 [![GitHub Releases (latest SemVer)](https://img.shields.io/github/v/release/iwill/ExCodable.svg?sort=semver)](https://github.com/iwill/ExCodable/releases)
 [![Deploy to CocoaPods](https://github.com/iwill/ExCodable/actions/workflows/deploy_to_cocoapods.yml/badge.svg)](https://github.com/iwill/ExCodable/actions/workflows/deploy_to_cocoapods.yml)
 [![Cocoapods](https://img.shields.io/cocoapods/v/ExCodable.svg)](https://cocoapods.org/pods/ExCodable)
+<br />
 [![LICENSE](https://img.shields.io/github/license/iwill/ExCodable.svg)](https://github.com/iwill/ExCodable/blob/master/LICENSE)
 [![@minglq](https://img.shields.io/twitter/url?url=https%3A%2F%2Fgithub.com%2Fiwill%2FExCodable)](https://twitter.com/minglq)
 
@@ -17,6 +19,7 @@ En | [中文](https://iwill.im/ExCodable/)
 - [Features](#features)
 - [Usage](#usage)
 - [Requirements](#requirements)
+- [Migration Guides](#migration-guides)
 - [Installation](#installation)
 - [Credits](#credits)
 - [License](#license)
@@ -24,7 +27,7 @@ En | [中文](https://iwill.im/ExCodable/)
 ## Features
 
 - Extends Swift `Codable` - `Encodable & Decodable`;
-- Supports Key-Mapping via `KeyPath` and Coding-Key:
+- Supports Key-Mapping via Property-Wrapper `ExCodable` + `String`:
     - `ExCodable` did not read/write memory via unsafe pointers;
     - No need to encode/decode properties one by one;
     - Just requires using `var` to declare properties and provide default values;
@@ -57,7 +60,7 @@ struct TestAutoCodable: Codable, Equatable {
 
 ```
 
-But, if you have to encode/decode manually for some reason, e.g. Alternative-Keys and Nested-Keys ...
+But, if you have to encode/decode manually for some reason, e.g. Default-Value, Alternative-Keys, Nested-Keys or Type-Conversions ...
 
 ```swift
 struct TestManualCodable: Equatable {

--- a/Sources/ExCodable/DecodingContainer+AnyCollection.swift
+++ b/Sources/ExCodable/DecodingContainer+AnyCollection.swift
@@ -1,0 +1,151 @@
+//
+//  DecodingContainer+AnyCollection.swift
+//  AnyDecodable
+//
+//  Created by levantAJ on 1/18/19.
+//  Copyright © 2019 levantAJ. All rights reserved.
+//
+//  https://github.com/levantAJ/AnyCodable
+import Foundation
+
+struct AnyCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String(intValue)
+    }
+}
+
+extension KeyedDecodingContainer {
+    /// Decodes a value of the given type for the given key.
+    ///
+    /// - parameter type: The type of value to decode.
+    /// - parameter key: The key that the decoded value is associated with.
+    /// - returns: A value of the requested type, if present for the given key
+    ///   and convertible to the requested type.
+    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
+    ///   is not convertible to the requested type.
+    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry
+    ///   for the given key.
+    /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for
+    ///   the given key.
+    public func decode(_ type: [Any].Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> [Any] {
+        var values = try nestedUnkeyedContainer(forKey: key)
+        return try values.decode(type)
+    }
+
+    /// Decodes a value of the given type for the given key.
+    ///
+    /// - parameter type: The type of value to decode.
+    /// - parameter key: The key that the decoded value is associated with.
+    /// - returns: A value of the requested type, if present for the given key
+    ///   and convertible to the requested type.
+    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
+    ///   is not convertible to the requested type.
+    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry
+    ///   for the given key.
+    /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for
+    ///   the given key.
+    public func decode(_ type: [String: Any].Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> [String: Any] {
+        let values = try nestedContainer(keyedBy: AnyCodingKey.self, forKey: key)
+        return try values.decode(type)
+    }
+
+    /// Decodes a value of the given type for the given key, if present.
+    ///
+    /// This method returns `nil` if the container does not have a value
+    /// associated with `key`, or if the value is null. The difference between
+    /// these states can be distinguished with a `contains(_:)` call.
+    ///
+    /// - parameter type: The type of value to decode.
+    /// - parameter key: The key that the decoded value is associated with.
+    /// - returns: A decoded value of the requested type, or `nil` if the
+    ///   `Decoder` does not have an entry associated with the given key, or if
+    ///   the value is a null value.
+    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
+    ///   is not convertible to the requested type.
+    public func decodeIfPresent(_ type: [Any].Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> [Any]? {
+        guard contains(key),
+            try decodeNil(forKey: key) == false else { return nil }
+        return try decode(type, forKey: key)
+    }
+
+    /// Decodes a value of the given type for the given key, if present.
+    ///
+    /// This method returns `nil` if the container does not have a value
+    /// associated with `key`, or if the value is null. The difference between
+    /// these states can be distinguished with a `contains(_:)` call.
+    ///
+    /// - parameter type: The type of value to decode.
+    /// - parameter key: The key that the decoded value is associated with.
+    /// - returns: A decoded value of the requested type, or `nil` if the
+    ///   `Decoder` does not have an entry associated with the given key, or if
+    ///   the value is a null value.
+    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value
+    ///   is not convertible to the requested type.
+    public func decodeIfPresent(_ type: [String: Any].Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> [String: Any]? {
+        guard contains(key),
+            try decodeNil(forKey: key) == false else { return nil }
+        return try decode(type, forKey: key)
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decode(_ type: [String: Any].Type) throws -> [String: Any] {
+        var dictionary: [String: Any] = [:]
+        for key in allKeys {
+            if try decodeNil(forKey: key) {
+                dictionary[key.stringValue] = NSNull()
+            } else if let bool = try? decode(Bool.self, forKey: key) {
+                dictionary[key.stringValue] = bool
+            } else if let string = try? decode(String.self, forKey: key) {
+                dictionary[key.stringValue] = string
+            } else if let int = try? decode(Int.self, forKey: key) {
+                dictionary[key.stringValue] = int
+            } else if let double = try? decode(Double.self, forKey: key) {
+                dictionary[key.stringValue] = double
+            } else if let dict = try? decode([String: Any].self, forKey: key) {
+                dictionary[key.stringValue] = dict
+            } else if let array = try? decode([Any].self, forKey: key) {
+                dictionary[key.stringValue] = array
+            }
+        }
+        return dictionary
+    }
+}
+
+private extension UnkeyedDecodingContainer {
+    mutating func decode(_ type: [Any].Type) throws -> [Any] {
+        var elements: [Any] = []
+        while !isAtEnd {
+            if try decodeNil() {
+                elements.append(NSNull())
+            } else if let int = try? decode(Int.self) {
+                elements.append(int)
+            } else if let bool = try? decode(Bool.self) {
+                elements.append(bool)
+            } else if let double = try? decode(Double.self) {
+                elements.append(double)
+            } else if let string = try? decode(String.self) {
+                elements.append(string)
+            } else if let values = try? nestedContainer(keyedBy: AnyCodingKey.self),
+                let element = try? values.decode([String: Any].self) {
+                elements.append(element)
+            } else if var values = try? nestedUnkeyedContainer(),
+                let element = try? values.decode([Any].self) {
+                elements.append(element)
+            }
+        }
+        return elements
+    }
+    mutating func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
+        let nestedContainer = try self.nestedContainer(keyedBy: AnyCodingKey.self)
+        return try nestedContainer.decode(type)
+    }
+}

--- a/Sources/ExCodable/EncodingContainer+AnyCollection.swift
+++ b/Sources/ExCodable/EncodingContainer+AnyCollection.swift
@@ -1,0 +1,131 @@
+//
+//  EncodingContainer+AnyCollection.swift
+//  AnyDecodable
+//
+//  Created by ShopBack on 1/19/19.
+//  Copyright © 2019 levantAJ. All rights reserved.
+//
+//  https://github.com/levantAJ/AnyCodable
+import Foundation
+
+extension KeyedEncodingContainer {
+    /// Encodes the given value for the given key.
+    ///
+    /// - parameter value: The value to encode.
+    /// - parameter key: The key to associate the value with.
+    /// - throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    public mutating func encode(_ value: [String: Any], forKey key: KeyedEncodingContainer<K>.Key) throws {
+        var container = nestedContainer(keyedBy: AnyCodingKey.self, forKey: key)
+        try container.encode(value)
+    }
+
+    /// Encodes the given value for the given key.
+    ///
+    /// - parameter value: The value to encode.
+    /// - parameter key: The key to associate the value with.
+    /// - throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    public mutating func encode(_ value: [Any], forKey key: KeyedEncodingContainer<K>.Key) throws {
+        var container = nestedUnkeyedContainer(forKey: key)
+        try container.encode(value)
+    }
+
+    /// Encodes the given value for the given key if it is not `nil`.
+    ///
+    /// - parameter value: The value to encode.
+    /// - parameter key: The key to associate the value with.
+    /// - throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    public mutating func encodeIfPresent(_ value: [String: Any]?, forKey key: KeyedEncodingContainer<K>.Key) throws {
+        if let value = value {
+            var container = nestedContainer(keyedBy: AnyCodingKey.self, forKey: key)
+            try container.encode(value)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+
+    /// Encodes the given value for the given key if it is not `nil`.
+    ///
+    /// - parameter value: The value to encode.
+    /// - parameter key: The key to associate the value with.
+    /// - throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    public mutating func encodeIfPresent(_ value: [Any]?, forKey key: KeyedEncodingContainer<K>.Key) throws {
+        if let value = value {
+            var container = nestedUnkeyedContainer(forKey: key)
+            try container.encode(value)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+}
+
+private extension KeyedEncodingContainer where K == AnyCodingKey {
+    mutating func encode(_ value: [String: Any]) throws {
+        for (k, v) in value {
+            let key = AnyCodingKey(stringValue: k)!
+            switch v {
+            case is NSNull:
+                try encodeNil(forKey: key)
+            case let string as String:
+                try encode(string, forKey: key)
+            case let int as Int:
+                try encode(int, forKey: key)
+            case let bool as Bool:
+                try encode(bool, forKey: key)
+            case let double as Double:
+                try encode(double, forKey: key)
+            case let dict as [String: Any]:
+                try encode(dict, forKey: key)
+            case let array as [Any]:
+                try encode(array, forKey: key)
+            default:
+                debugPrint("⚠️ Unsuported type!", v)
+                continue
+            }
+        }
+    }
+}
+
+private extension UnkeyedEncodingContainer {
+    /// Encodes the given value.
+    ///
+    /// - parameter value: The value to encode.
+    /// - throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    mutating func encode(_ value: [Any]) throws {
+        for v in value {
+            switch v {
+            case is NSNull:
+                try encodeNil()
+            case let string as String:
+                try encode(string)
+            case let int as Int:
+                try encode(int)
+            case let bool as Bool:
+                try encode(bool)
+            case let double as Double:
+                try encode(double)
+            case let dict as [String: Any]:
+                try encode(dict)
+            case let array as [Any]:
+                var values = nestedUnkeyedContainer()
+                try values.encode(array)
+            default:
+                debugPrint("⚠️ Unsuported type!", v)
+            }
+        }
+    }
+
+    /// Encodes the given value.
+    ///
+    /// - parameter value: The value to encode.
+    /// - throws: `EncodingError.invalidValue` if the given value is invalid in
+    ///   the current context for this format.
+    mutating func encode(_ value: [String: Any]) throws {
+        var container = self.nestedContainer(keyedBy: AnyCodingKey.self)
+        try container.encode(value)
+    }
+}

--- a/Sources/ExCodable/ExCodable+DEPRECATED.swift
+++ b/Sources/ExCodable/ExCodable+DEPRECATED.swift
@@ -8,7 +8,100 @@
 
 import Foundation
 
-public extension ExCodable {
+// MARK: - keyMapping
+
+@available(*, deprecated, message: "use `@ExCodable` property wrapper instead")
+public protocol ExCodableProtocol: Codable {
+    associatedtype Root = Self where Root: ExCodableProtocol
+    static var keyMapping: [KeyMap<Root>] { get }
+}
+
+@available(*, deprecated)
+public extension ExCodableProtocol where Root == Self {
+    
+    // default implementation of ExCodableProtocol
+    static var keyMapping: [KeyMap<Root>] { [] }
+    
+    // default implementation of Encodable
+    func encode(to encoder: Encoder) throws {
+        try encode(to: encoder, with: Self.keyMapping)
+        try encode(to: encoder, nonnull: false, throws: false)
+    }
+    
+    func decode(from decoder: Decoder) throws {
+        try decode(from: decoder, nonnull: false, throws: false)
+    }
+}
+
+@available(*, deprecated)
+public extension ExCodableProtocol {
+    func encode(to encoder: Encoder, with keyMapping: [KeyMap<Self>], nonnull: Bool = false, throws: Bool = false) throws {
+        try keyMapping.forEach { try $0.encode(self, encoder, nonnull, `throws`) }
+    }
+    mutating func decode(from decoder: Decoder, with keyMapping: [KeyMap<Self>], nonnull: Bool = false, throws: Bool = false) throws {
+        try keyMapping.forEach { try $0.decode?(&self, decoder, nonnull, `throws`) }
+    }
+    func decodeReference(from decoder: Decoder, with keyMapping: [KeyMap<Self>], nonnull: Bool = false, throws: Bool = false) throws {
+        try keyMapping.forEach { try $0.decodeReference?(self, decoder, nonnull, `throws`) }
+    }
+}
+
+@available(*, deprecated, message: "use `@ExCodable` property wrapper instead")
+public final class KeyMap<Root: Codable> {
+    fileprivate let encode: (_ root: Root, _ encoder: Encoder, _ nonnullAll: Bool, _ throwsAll: Bool) throws -> Void
+    fileprivate let decode: ((_ root: inout Root, _ decoder: Decoder, _ nonnullAll: Bool, _ throwsAll: Bool) throws -> Void)?
+    fileprivate let decodeReference: ((_ root: Root, _ decoder: Decoder, _ nonnullAll: Bool, _ throwsAll: Bool) throws -> Void)?
+    private init(encode: @escaping (_ root: Root, _ encoder: Encoder, _ nonnullAll: Bool, _ throwsAll: Bool) throws -> Void,
+                 decode: ((_ root: inout Root, _ decoder: Decoder, _ nonnullAll: Bool, _ throwsAll: Bool) throws -> Void)?,
+                 decodeReference: ((_ root: Root, _ decoder: Decoder, _ nonnullAll: Bool, _ throwsAll: Bool) throws -> Void)?) {
+        (self.encode, self.decode, self.decodeReference) = (encode, decode, decodeReference)
+    }
+}
+
+@available(*, deprecated)
+public extension KeyMap {
+    convenience init<Value: Codable>(_ keyPath: WritableKeyPath<Root, Value>, to codingKeys: String ..., nonnull: Bool? = nil, throws: Bool? = nil) {
+        self.init(encode: { root, encoder, nonnullAll, throwsAll in
+            try encoder.encode(root[keyPath: keyPath], for: codingKeys.first!, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll)
+        }, decode: { root, decoder, nonnullAll, throwsAll in
+            if let value: Value = try decoder.decode(codingKeys, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll) {
+                root[keyPath: keyPath] = value
+            }
+        }, decodeReference: nil)
+    }
+    convenience init<Value: Codable, Key: CodingKey>(_ keyPath: WritableKeyPath<Root, Value>, to codingKeys: Key ..., nonnull: Bool? = nil, throws: Bool? = nil) {
+        self.init(encode: { root, encoder, nonnullAll, throwsAll in
+            try encoder.encode(root[keyPath: keyPath], for: codingKeys.first!, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll)
+        }, decode: { root, decoder, nonnullAll, throwsAll in
+            if let value: Value = try decoder.decode(codingKeys, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll) {
+                root[keyPath: keyPath] = value
+            }
+        }, decodeReference: nil)
+    }
+    convenience init<Value: Codable>(ref keyPath: ReferenceWritableKeyPath<Root, Value>, to codingKeys: String ..., nonnull: Bool? = nil, throws: Bool? = nil) {
+        self.init(encode: { root, encoder, nonnullAll, throwsAll in
+            try encoder.encode(root[keyPath: keyPath], for: codingKeys.first!, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll)
+        }, decode: nil, decodeReference: { root, decoder, nonnullAll, throwsAll in
+            if let value: Value = try decoder.decode(codingKeys, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll) {
+                root[keyPath: keyPath] = value
+            }
+        })
+    }
+    convenience init<Value: Codable, Key: CodingKey>(ref keyPath: ReferenceWritableKeyPath<Root, Value>, to codingKeys: Key ..., nonnull: Bool? = nil, throws: Bool? = nil) {
+        self.init(encode: { root, encoder, nonnullAll, throwsAll in
+            try encoder.encode(root[keyPath: keyPath], for: codingKeys.first!, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll)
+        }, decode: nil, decodeReference: { root, decoder, nonnullAll, throwsAll in
+            if let value: Value = try decoder.decode(codingKeys, nonnull: nonnull ?? nonnullAll, throws: `throws` ?? throwsAll) {
+                root[keyPath: keyPath] = value
+            }
+        })
+    }
+}
+
+// MARK: -
+
+@available(*, deprecated)
+public extension ExCodableProtocol {
     @available(*, deprecated, renamed: "encode(to:with:nonnull:throws:)")
     func encode(with keyMapping: [KeyMap<Self>], using encoder: Encoder) {
         try? encode(to: encoder, with: keyMapping)

--- a/Sources/ExCodable/ExCodable+DEPRECATED.swift
+++ b/Sources/ExCodable/ExCodable+DEPRECATED.swift
@@ -2,8 +2,8 @@
 //  ExCodable.swift
 //  ExCodable
 //
-//  Created by Mr. Ming on 2021-07-01.
-//  Copyright (c) 2021 Mr. Ming <minglq.9@gmail.com>. Released under the MIT license.
+//  Created by Mr. Míng on 2021-07-01.
+//  Copyright (c) 2021 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
 //
 
 import Foundation

--- a/Sources/ExCodable/ExCodable+DEPRECATED.swift
+++ b/Sources/ExCodable/ExCodable+DEPRECATED.swift
@@ -1,0 +1,35 @@
+//
+//  ExCodable.swift
+//  ExCodable
+//
+//  Created by Mr. Ming on 2021-07-01.
+//  Copyright (c) 2021 Mr. Ming <minglq.9@gmail.com>. Released under the MIT license.
+//
+
+import Foundation
+
+public extension ExCodable {
+    @available(*, deprecated, renamed: "encode(to:with:nonnull:throws:)")
+    func encode(with keyMapping: [KeyMap<Self>], using encoder: Encoder) {
+        try? encode(to: encoder, with: keyMapping)
+    }
+    @available(*, deprecated, renamed: "decode(from:with:nonnull:throws:)")
+    mutating func decode(with keyMapping: [KeyMap<Self>], using decoder: Decoder) {
+        try? decode(from: decoder, with: keyMapping)
+    }
+    @available(*, deprecated, renamed: "decodeReference(from:with:nonnull:throws:)")
+    func decodeReference(with keyMapping: [KeyMap<Self>], using decoder: Decoder) {
+        try? decodeReference(from: decoder, with: keyMapping)
+    }
+}
+
+@available(*, deprecated, renamed: "append(decodingTypeConverter:)")
+public protocol KeyedDecodingContainerCustomTypeConversion: ExCodableDecodingTypeConverter {
+    func decodeForTypeConversion<T: Decodable, K: CodingKey>(_ container: KeyedDecodingContainer<K>, codingKey: K, as type: T.Type) -> T?
+}
+@available(*, deprecated)
+public extension KeyedDecodingContainerCustomTypeConversion {
+    func decode<T: Decodable, K: CodingKey>(_ container: KeyedDecodingContainer<K>, codingKey: K, as type: T.Type) throws -> T? {
+        return decodeForTypeConversion(container, codingKey: codingKey, as: type)
+    }
+}

--- a/Sources/ExCodable/ExCodable+DEPRECATED.swift
+++ b/Sources/ExCodable/ExCodable+DEPRECATED.swift
@@ -18,16 +18,13 @@ public protocol ExCodableProtocol: Codable {
 
 @available(*, deprecated)
 public extension ExCodableProtocol where Root == Self {
-    
     // default implementation of ExCodableProtocol
     static var keyMapping: [KeyMap<Root>] { [] }
-    
     // default implementation of Encodable
     func encode(to encoder: Encoder) throws {
         try encode(to: encoder, with: Self.keyMapping)
         try encode(to: encoder, nonnull: false, throws: false)
     }
-    
     func decode(from decoder: Decoder) throws {
         try decode(from: decoder, nonnull: false, throws: false)
     }

--- a/Sources/ExCodable/ExCodable+DEPRECATED.swift
+++ b/Sources/ExCodable/ExCodable+DEPRECATED.swift
@@ -3,7 +3,7 @@
 //  ExCodable
 //
 //  Created by Mr. Míng on 2021-07-01.
-//  Copyright (c) 2021 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
+//  Copyright (c) 2022 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
 //
 
 import Foundation

--- a/Sources/ExCodable/ExCodable.swift
+++ b/Sources/ExCodable/ExCodable.swift
@@ -11,20 +11,20 @@ import Foundation
 /**
  *  # ExCodable
  *  
- *  - `ExCodable`: A property-wrapper for mapping property to json-key.
- *  - `ExAutoEncodable` and `ExAutoDecodable`: Protocols with default implementation for Encodable & Decodable.
+ *  - `ExCodable`: A property-wrapper for mapping properties to JSON keys.
+ *  - `ExAutoEncodable` & `ExAutoDecodable`: Protocols with default implementation for Encodable & Decodable.
  *  - `ExAutoCodable`: A typealias for `ExAutoEncodable & ExAutoDecodable`.
- *  - Extensions of `Encodable & Decodable`, for encode/decode-ing from internal/external.
- *  - Extensions of `Encoder & Encoder`, for encode/decode-ing properties one-by-one.
- *  - Supports alternative-keys, nested-keys and type-conversion
+ *  - `Encodable` & `Decodable` extensions for encode/decode-ing from internal/external.
+ *  - `Encoder` & `Encoder` extensions for encode/decode-ing properties one by one.
+ *  - Supports Alternative-Keys, Nested-Keys, Type-Conversions and Default-Values.
  *  
  *  <#swift#> <#codable#> <#json#> <#model#> <#type-inference#>
- *  <#property-wrapper#> <#key-mapping#> <#codingkey#> <#subscript#>
- *  <#alternative-keys#> <#nested-keys#> <#type-conversion#>
+ *  <#key-mapping#> <#property-wrapper#> <#coding-key#> <#subscript#>
+ *  <#alternative-keys#> <#nested-keys#> <#type-conversions#>
  *  
- *  - seealso: [Usage](https://github.com/iwill/ExCodable#usage) from GitGub
- *  - seealso: `ExCodableTests.swift` form the source code
- *  - seealso: Idea from [Decoding and overriding](https://www.swiftbysundell.com/articles/property-wrappers-in-swift/#decoding-and-overriding), by John Sundell.
+ *  - seealso: [Usage](https://github.com/iwill/ExCodable#usage) from the `README.md`
+ *  - seealso: `ExCodableTests.swift` from the `Tests`
+ *  - seealso: [Decoding and overriding](https://www.swiftbysundell.com/articles/property-wrappers-in-swift/#decoding-and-overriding) and [Useful Codable extensions](https://www.swiftbysundell.com/tips/useful-codable-extensions/), by John Sundell.
  */
 
 @propertyWrapper
@@ -59,7 +59,6 @@ extension ExCodable: EncodablePropertyWrapper where Value: Encodable {
     fileprivate func encode<Label: StringProtocol>(to encoder: Encoder, label: Label, nonnull: Bool, throws: Bool) throws {
         if encode != nil { try encode!(encoder, wrappedValue) }
         else { try encoder.encode(wrappedValue, for: stringKeys?.first ?? String(label), nonnull: self.nonnull ?? nonnull, throws: self.throws ?? `throws`) }
-        
     }
 }
 
@@ -263,7 +262,7 @@ extension ExCodingKey: CodingKey {
     public init?(intValue: Int) { self.init(intValue) }
 }
 
-// MARK: - KeyedDecodingContainer - alternative-keys + nested-keys + type-conversion
+// MARK: - KeyedDecodingContainer - alternative-keys + nested-keys + type-conversions
 
 fileprivate extension KeyedDecodingContainer {
     

--- a/Sources/ExCodable/ExCodable.swift
+++ b/Sources/ExCodable/ExCodable.swift
@@ -3,7 +3,7 @@
 //  ExCodable
 //
 //  Created by Mr. Míng on 2021-02-10.
-//  Copyright (c) 2021 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
+//  Copyright (c) 2022 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
 //
 
 import Foundation

--- a/Sources/ExCodable/ExCodable.swift
+++ b/Sources/ExCodable/ExCodable.swift
@@ -51,6 +51,10 @@ extension ExCodable: Equatable where Value: Equatable {
         return lhs.wrappedValue == rhs.wrappedValue
     }
 }
+extension ExCodable: CustomStringConvertible { // CustomDebugStringConvertible
+    public var description: String { String(describing: wrappedValue) }
+    // public var debugDescription: String { "\(type(of: self))(\(wrappedValue))" }
+}
 
 fileprivate protocol EncodablePropertyWrapper {
     func encode<Label: StringProtocol>(to encoder: Encoder, label: Label, nonnull: Bool, throws: Bool) throws

--- a/Sources/ExCodable/ExCodable.swift
+++ b/Sources/ExCodable/ExCodable.swift
@@ -2,8 +2,8 @@
 //  ExCodable.swift
 //  ExCodable
 //
-//  Created by Mr. Ming on 2021-02-10.
-//  Copyright (c) 2021 Mr. Ming <minglq.9@gmail.com>. Released under the MIT license.
+//  Created by Mr. Míng on 2021-02-10.
+//  Copyright (c) 2021 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
 //
 
 import Foundation

--- a/Tests/ExCodableTests/ExCodableTests.swift
+++ b/Tests/ExCodableTests/ExCodableTests.swift
@@ -90,14 +90,14 @@ extension TestNestedKeys: ExAutoCodable {}
 // MARK: custom encode/decode
 
 struct TestCustomEncodeDecode: Equatable {
+    
     @ExCodable(Keys.int)
     var int: Int = 0
+    
     var string: String?
-    @ExCodable(encode: { encoder, value in
-        encoder[Keys.bool] = value
-    }, decode: { decoder in
-        return decoder[Keys.bool]
-    })
+    
+    @ExCodable(encode: { encoder, value in encoder[Keys.bool] = value },
+               decode: { decoder in return decoder[Keys.bool] })
     var bool: Bool = false
 }
 

--- a/Tests/ExCodableTests/ExCodableTests.swift
+++ b/Tests/ExCodableTests/ExCodableTests.swift
@@ -82,7 +82,7 @@ extension TestAlternativeKeys: ExAutoCodable {}
 struct TestNestedKeys: Equatable {
     @ExCodable
     var int: Int = 0
-    @ExCodable("nested.string")
+    @ExCodable("nested.nested.string")
     var string: String! = nil
 }
 extension TestNestedKeys: ExAutoCodable {}
@@ -396,7 +396,9 @@ final class ExCodableTests: XCTestCase {
             XCTAssertEqual(NSDictionary(dictionary: json), [
                 "int": 404,
                 "nested": [
-                    "string": "Not Found"
+                    "nested": [
+                        "string": "Not Found"
+                    ]
                 ]
             ])
         }

--- a/Tests/ExCodableTests/ExCodableTests.swift
+++ b/Tests/ExCodableTests/ExCodableTests.swift
@@ -2,8 +2,8 @@
 //  ExCodableTests.swift
 //  ExCodable
 //
-//  Created by Mr. Ming on 2021-02-10.
-//  Copyright (c) 2021 Mr. Ming <minglq.9@gmail.com>. Released under the MIT license.
+//  Created by Mr. Míng on 2021-02-10.
+//  Copyright (c) 2021 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
 //
 
 import XCTest

--- a/Tests/ExCodableTests/ExCodableTests.swift
+++ b/Tests/ExCodableTests/ExCodableTests.swift
@@ -59,93 +59,52 @@ extension TestManualCodable: Codable {
 // MARK: struct
 
 struct TestStruct: Equatable {
+    @ExCodable("int")
     private(set) var int: Int = 0
-    private(set) var string: String?
+    @ExCodable("string")
+    private(set) var string: String? = nil
     var bool: Bool!
 }
-
-extension TestStruct: ExCodable {
-    
-    static let keyMapping: [KeyMap<Self>] = [
-        KeyMap(\.int, to: "int"),
-        KeyMap(\.string, to: "string"),
-    ]
-    
-    init(from decoder: Decoder) throws {
-        try decode(from: decoder, with: Self.keyMapping)
-    }
-    // `encode` with default implementation can be omitted
-    // func encode(to encoder: Encoder) throws {
-    //     try encode(to: encoder, with: Self.keyMapping)
-    // }
-}
+extension TestStruct: ExAutoCodable {}
 
 // MARK: alternative-keys & alternative-keyMapping
 
 struct TestAlternativeKeys: Equatable {
+    @ExCodable("int", "i")
     var int: Int = 0
-    var string: String!
+    @ExCodable("string", "str", "s")
+    var string: String! = nil
 }
-
-extension TestAlternativeKeys: ExCodable {
-    
-    static let keyMapping: [KeyMap<Self>] = [
-        KeyMap(\.int, to: "int", "i"),
-        KeyMap(\.string, to: "string", "str", "s")
-    ]
-    
-    static let keyMappingFromLocal: [KeyMap<Self>] = [
-        KeyMap(\.int, to: "INT"),
-        KeyMap(\.string, to: "STRING")
-    ]
-    
-    enum LocalKeys: String, CodingKey {
-        case isLocal = "_IS_LOCAL_"
-    }
-    
-    init(from decoder: Decoder) throws {
-        let isLocal = decoder[LocalKeys.isLocal] ?? false
-        try decode(from: decoder, with: isLocal ? Self.keyMappingFromLocal : Self.keyMapping)
-    }
-    func encode(to encoder: Encoder) throws {
-        try encode(to: encoder, with: Self.keyMappingFromLocal)
-        encoder[LocalKeys.isLocal] = true
-    }
-}
+extension TestAlternativeKeys: ExAutoCodable {}
 
 // MARK: nested-keys
 
 struct TestNestedKeys: Equatable {
+    @ExCodable
     var int: Int = 0
-    var string: String!
+    @ExCodable("nested.string")
+    var string: String! = nil
 }
-
-extension TestNestedKeys: ExCodable {
-    
-    static let keyMapping: [KeyMap<Self>] = [
-        KeyMap(\.int, to: "int"),
-        KeyMap(\.string, to: "nested.string")
-    ]
-    
-    init(from decoder: Decoder) throws {
-        try decode(from: decoder, with: Self.keyMapping)
-    }
-    // func encode(to encoder: Encoder) throws {
-    //     try encode(to: encoder, with: Self.keyMapping)
-    // }
-}
+extension TestNestedKeys: ExAutoCodable {}
 
 // MARK: custom encode/decode
 
 struct TestCustomEncodeDecode: Equatable {
+    @ExCodable(Keys.int)
     var int: Int = 0
     var string: String?
+    @ExCodable(encode: { encoder, value in
+        encoder[Keys.bool] = value
+    }, decode: { decoder in
+        return decoder[Keys.bool]
+    })
+    var bool: Bool = false
 }
 
-extension TestCustomEncodeDecode: ExCodable {
+extension TestCustomEncodeDecode: Codable {
     
     private enum Keys: CodingKey {
-        case int, string
+        case int, string, bool
     }
     private static let dddd = "dddd"
     private func string(for int: Int) -> String {
@@ -162,19 +121,15 @@ extension TestCustomEncodeDecode: ExCodable {
         }
     }
     
-    static let keyMapping: [KeyMap<Self>] = [
-        KeyMap(\.int, to: Keys.int),
-    ]
-    
     init(from decoder: Decoder) throws {
-        try decode(from: decoder, with: Self.keyMapping)
+        try decode(from: decoder, nonnull: false, throws: false)
         string = decoder[Keys.string]
         if string == nil || string == Self.dddd {
             string = string(for: int)
         }
     }
     func encode(to encoder: Encoder) throws {
-        try encode(to: encoder, with: Self.keyMapping)
+        try encode(to: encoder, nonnull: false, throws: false)
         encoder[Keys.string] = Self.dddd
     }
 }
@@ -309,44 +264,29 @@ struct FloatToBoolDecodingTypeConverter: ExCodableDecodingTypeConverter {
 }
 
 struct TestCustomTypeConverter: Equatable {
+    @ExCodable("doubleFromBool")
     var doubleFromBool: Double? = nil
 }
-
-extension TestCustomTypeConverter: ExCodable {
-    
-    static let keyMapping: [KeyMap<Self>] = [
-        KeyMap(\.doubleFromBool, to: "doubleFromBool")
-    ]
-    
-    init(from decoder: Decoder) throws {
-        try decode(from: decoder, with: Self.keyMapping)
-    }
-    // func encode(to encoder: Encoder) throws {
-    //     try encode(to: encoder, with: Self.keyMapping)
-    // }
-}
+extension TestCustomTypeConverter: ExAutoCodable {}
 
 // MARK: class
 
-class TestClass: ExCodable, Equatable {
+class TestClass: Codable, Equatable {
     
+    @ExCodable("int")
     var int: Int = 0
+    @ExCodable("string")
     var string: String? = nil
     init(int: Int, string: String?) {
         (self.int, self.string) = (int, string)
     }
     
-    static let keyMapping: [KeyMap<TestClass>] = [
-        KeyMap(ref: \.int, to: "int"),
-        KeyMap(ref: \.string, to: "string")
-    ]
-    
     required init(from decoder: Decoder) throws {
-        try decodeReference(from: decoder, with: Self.keyMapping)
+        try decode(from: decoder, nonnull: false, throws: false)
     }
-    // func encode(to encoder: Encoder) throws {
-    //     try encode(to: encoder, with: Self.keyMapping)
-    // }
+    func encode(to encoder: Encoder) throws {
+        try encode(to: encoder, nonnull: false, throws: false)
+    }
     
     static func == (lhs: TestClass, rhs: TestClass) -> Bool {
         return lhs.int == rhs.int && lhs.string == rhs.string
@@ -356,23 +296,16 @@ class TestClass: ExCodable, Equatable {
 // MARK: subclass
 
 class TestSubclass: TestClass {
+    
+    @ExCodable("bool")
     var bool: Bool = false
     required init(int: Int, string: String, bool: Bool) {
         self.bool = bool
         super.init(int: int, string: string)
     }
     
-    static let keyMappingForTestSubclass: [KeyMap<TestSubclass>] = [
-        KeyMap(ref: \.bool, to: "bool")
-    ]
-    
     required init(from decoder: Decoder) throws {
         try super.init(from: decoder)
-        try decodeReference(from: decoder, with: Self.keyMappingForTestSubclass)
-    }
-    override func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-        try encode(to: encoder, with: Self.keyMappingForTestSubclass)
     }
     
     static func == (lhs: TestSubclass, rhs: TestSubclass) -> Bool {
@@ -385,24 +318,12 @@ class TestSubclass: TestClass {
 // MARK: ExCodable
 
 struct TestExCodable: Equatable {
+    @ExCodable("int")
     private(set) var int: Int = 0
-    private(set) var string: String?
+    @ExCodable("string")
+    private(set) var string: String? = nil
 }
-
-extension TestExCodable: ExCodable {
-    
-    static let keyMapping: [KeyMap<Self>] = [
-        KeyMap(\.int, to: "int"),
-        KeyMap(\.string, to: "string")
-    ]
-    
-    init(from decoder: Decoder) throws {
-        try decode(from: decoder, with: Self.keyMapping)
-    }
-    // func encode(to encoder: Encoder) throws {
-    //     try encode(to: encoder, with: Self.keyMapping)
-    // }
-}
+extension TestExCodable: ExAutoCodable {}
 
 // MARK: - Tests
 
@@ -456,9 +377,8 @@ final class ExCodableTests: XCTestCase {
             XCTAssertEqual(copy, test)
             let localJSON: [String: Any] = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
             XCTAssertEqual(NSDictionary(dictionary: localJSON), [
-                "_IS_LOCAL_": true,
-                "INT": 403,
-                "STRING": "Forbidden"
+                "int": 403,
+                "string": "Forbidden"
             ])
         }
         else {
@@ -486,7 +406,7 @@ final class ExCodableTests: XCTestCase {
     }
     
     func testCustomEncodeDecode() {
-        let test = TestCustomEncodeDecode(int: 418, string: "I'm a teapot")
+        let test = TestCustomEncodeDecode(int: 418, string: "I'm a teapot", bool: true)
         if let data = try? test.encoded() as Data,
            let copy = try? data.decoded() as TestCustomEncodeDecode {
             XCTAssertEqual(copy, test)
@@ -494,7 +414,8 @@ final class ExCodableTests: XCTestCase {
             debugPrint(json)
             XCTAssertEqual(NSDictionary(dictionary: json), [
                 "int": 418,
-                "string": "dddd"
+                "string": "dddd",
+                "bool": true
             ])
         }
         else {

--- a/Tests/ExCodableTests/ExCodableTests.swift
+++ b/Tests/ExCodableTests/ExCodableTests.swift
@@ -333,7 +333,7 @@ final class ExCodableTests: XCTestCase {
         let test = TestAutoCodable(int: 100, string: "Continue")
         if let data = try? test.encoded() as Data,
            let copy = try? data.decoded() as TestAutoCodable,
-           let json: [String: Any] = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             XCTAssertEqual(copy, test)
             XCTAssertEqual(NSDictionary(dictionary: json), ["i": 100, "s": "Continue"])
         }
@@ -375,7 +375,7 @@ final class ExCodableTests: XCTestCase {
            let copy = try? data.decoded() as TestAlternativeKeys {
             XCTAssertEqual(test, TestAlternativeKeys(int: 403, string: "Forbidden"))
             XCTAssertEqual(copy, test)
-            let localJSON: [String: Any] = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+            let localJSON = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
             XCTAssertEqual(NSDictionary(dictionary: localJSON), [
                 "int": 403,
                 "string": "Forbidden"
@@ -391,7 +391,7 @@ final class ExCodableTests: XCTestCase {
         if let data = try? test.encoded() as Data,
            let copy = try? data.decoded() as TestNestedKeys {
             XCTAssertEqual(copy, test)
-            let json: [String: Any] = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+            let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
             debugPrint(json)
             XCTAssertEqual(NSDictionary(dictionary: json), [
                 "int": 404,
@@ -410,7 +410,7 @@ final class ExCodableTests: XCTestCase {
         if let data = try? test.encoded() as Data,
            let copy = try? data.decoded() as TestCustomEncodeDecode {
             XCTAssertEqual(copy, test)
-            let json: [String: Any] = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+            let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
             debugPrint(json)
             XCTAssertEqual(NSDictionary(dictionary: json), [
                 "int": 418,

--- a/Tests/ExCodableTests/ExCodableTests.swift
+++ b/Tests/ExCodableTests/ExCodableTests.swift
@@ -3,7 +3,7 @@
 //  ExCodable
 //
 //  Created by Mr. Míng on 2021-02-10.
-//  Copyright (c) 2021 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
+//  Copyright (c) 2022 Mr. Míng <minglq.9@gmail.com>. Released under the MIT license.
 //
 
 import XCTest


### PR DESCRIPTION
让 [String: Any], [Any]支持Codable，模型定义如下

struct testModel: ExAutoCodable {
    @ExCodable
    var jumpParam: [String: Any]? = [:]

    @ExCodable
    var matchs: [Any] = []
}